### PR TITLE
Fix Measurement{Float64}(::Rational)

### DIFF
--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -59,6 +59,7 @@ function Measurement(val::V, err::E, tag::UInt64,
 end
 Measurement{T}(x::Measurement{S}) where {T,S} = convert(Measurement{T}, x)
 Measurement{T}(x::S) where {T,S} = measurement(x)
+Measurement{T}(x::S) where {T,S<:Rational} = measurement(x)
 
 # Functions to quickly create an empty Derivatives object.
 @generated empty_der1(x::Measurement{T}) where {T<:AbstractFloat} = Derivatives{T}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -715,6 +715,7 @@ end
 
 @testset "Fixed bugs" begin
     @test 1 * (big(3) ± 0) ≈ 3 ± 0
+    @test Measurement{Float64}(2//1) === Measurement{Float64}(2.0)
 end
 
 @testset "Complex measurements" begin


### PR DESCRIPTION
Before this, `Measurement{Float64}(2//1)` would result in

```julia
MethodError: Measurement{Float64}(::Rational{Int64}) is ambiguous. Candidates:
  (::Type{Measurement{T}})(x::S) where {T, S} in Measurements at /home/twan/.julia/packages/Measurements/57KtG/src/Measurements.jl:61
  (::Type{T})(x::Rational{S}) where {S, T<:AbstractFloat} in Base at rational.jl:90
Possible fix, define
  (::Type{Measurement{T}})(::Rational{S})
```

on Julia 1.0.