### PR TITLE
Avoid creating a useless tuple from an array in at-uncertain macro

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -166,8 +166,8 @@ macro uncertain(expr::Expr)
         argsval =:([])  # Build up the array of values of arguments
         [push!(argsval.args, :($(args.args[i]).val)) for i=1:n] # Fill the array
         return :( result($f($argsval...),
-                         (Calculus.gradient(x -> $f(x...), $argsval)...,),
-                         ($args...,)) )
+                         Calculus.gradient(x -> $f(x...), $argsval),
+                         $args) )
     end
 end
 


### PR DESCRIPTION
Thanks @dpshelio for spotting this!

For example, on `master`:

```
julia> @benchmark @uncertain atan(1, 2)
BenchmarkTools.Trial: 
  memory estimate:  864 bytes
  allocs estimate:  26
  --------------
  minimum time:     933.957 ns (0.00% GC)
  median time:      960.522 ns (0.00% GC)
  mean time:        1.265 μs (19.62% GC)
  maximum time:     1.731 ms (99.90% GC)
  --------------
  samples:          10000
  evals/sample:     23
```

With this PR:
```
julia> @benchmark @uncertain atan(1, 2)
BenchmarkTools.Trial: 
  memory estimate:  768 bytes
  allocs estimate:  22
  --------------
  minimum time:     495.918 ns (0.00% GC)
  median time:      517.732 ns (0.00% GC)
  mean time:        594.881 ns (10.37% GC)
  maximum time:     211.667 μs (99.72% GC)
  --------------
  samples:          10000
  evals/sample:     194
```