### PR TITLE
Improve docstring of `uncertainty_components`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,10 @@ RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
-Calculus = "≥ 0.4.1"
-QuadGK = "≥ 2.0.1"
-RecipesBase = "≥ 0.6.0"
-Requires = "≥ 0.5.0"
-SpecialFunctions = "≥ 0.7.0"
-julia = "≥ 1.0.0"
+Calculus = "0.4.1, 0.5"
+RecipesBase = "0.6.0, 0.7"
+Requires = "0.5.0"
+julia = "1"
 
 [extras]
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,20 +1,3 @@
-### utils.jl
-#
-# Copyright (C) 2016, 2017 Mosè Giordano.
-#
-# Maintainer: Mosè Giordano <mose AT gnu DOT org>
-# Keywords: uncertainty, error propagation, physics
-#
-# This file is a part of Measurements.jl.
-#
-# License is MIT "Expat".
-#
-### Commentary:
-#
-# This file defines some utility functions.
-#
-### Code:
-
 export stdscore, weightedmean
 using LinearAlgebra
 
@@ -102,7 +85,13 @@ uncertainty
     Measurements.uncertainty_components(x::Measurement)
 
 Return the components to the uncertainty of the dependent quantity `x` in the
-form of a `Dict`.
+form of a `Dict` for all the independent `Measurement`s from which `x` is
+derived.
+
+The key of each entry of the dictionary is the triplet (value, uncertainty, tag)
+of an independent `Measurement`, and the value is the absolute value of the
+product between its uncertainty and the partial derivative of `x` with respect
+to this `Measurement`.
 """
 function uncertainty_components(x::Measurement{T}) where {T<:AbstractFloat}
     out = Dict{Tuple{T, T, UInt64}, T}()


### PR DESCRIPTION
@scheidan this should answer your questions.  If it's still unclear what the tag is, have a look at https://juliaphysics.github.io/Measurements.jl/stable/appendix/#The-Measurement-Type-1.  Let me know if there is something still not clear

Fix #53.