### PR TITLE
Fix broadcasting with ranges

### DIFF
--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -111,5 +111,6 @@ include("math.jl")
 include("show.jl")
 include("parsing.jl")
 include("plot-recipes.jl")
+include("misc.jl")
 
 end # module

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -1,0 +1,11 @@
+using Base: Broadcast.DefaultArrayStyle, AbstractUnitRange
+
+_broadcasted(style, f, x, r::AbstractRange) = invoke(Base.Broadcast.broadcasted, Tuple{typeof(style),typeof(f),Any,typeof(r)}, style, f, x, r)
+_broadcasted(style, f, r::AbstractRange, x) = invoke(Base.Broadcast.broadcasted, Tuple{typeof(style),typeof(f),typeof(r),Any}, style, f, r, x)
+
+for f in (+, -, *, /, \), R in (AbstractRange, AbstractUnitRange, StepRangeLen)
+    @eval begin
+        Base.Broadcast.broadcasted(style::DefaultArrayStyle{1}, ::typeof($f), x::Measurement, r::$R) = _broadcasted(style, $f, x, r)
+        Base.Broadcast.broadcasted(style::DefaultArrayStyle{1}, ::typeof($f), r::$R, x::Measurement) = _broadcasted(style, $f, r, x)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -783,3 +783,11 @@ end
 @testset "Plot recipes" begin
     include("plots.jl")
 end
+
+@testset begin "Broadcasting with ranges"
+    m = 2 ± 1
+    @test m .+ (1:6) isa Vector{<:Measurement}
+    @test m .* (1:2:6) isa Vector{<:Measurement}
+    @test (1:.1:6) .- m isa Vector{<:Measurement}
+    @test m ./ (1:6.0) isa Vector{<:Measurement}
+end


### PR DESCRIPTION
Julia tries to do some clever magic, when broadcasting numbers and ranges, defined [here](https://github.com/JuliaLang/julia/blob/master/base/broadcast.jl#L1028). This breaks things like `measurement(2, 1) .* (1:6)`, because right now, `Measurement`s don't support ranges. Eventually, it might be a good idea to implement ranges of `Measurement`s properly. This now just returns an `Array` in these cases and is a bit hacky, but works.