### PR TITLE
propagate missing in measurement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,16 @@ v2.1.1 (2019-08-05)
   ([#49](https://github.com/JuliaPhysics/Measurements.jl/issues/49),
   [#50](https://github.com/JuliaPhysics/Measurements.jl/pull/50)).
 
+v2.2.0 (2020-xx-xx)
+-------------------
+
+### New Features
+
+* `measurement(missing)`, `measurement(missing, ::Real)` and
+  `measurement(missing, missing)` will now return `missing`
+  ([#59](https://github.com/JuliaPhysics/Measurements.jl/issues/59),
+  [#62](https://github.com/JuliaPhysics/Measurements.jl/pull/62))
+
 v2.1.0 (2019-08-03)
 -------------------
 

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -95,6 +95,7 @@ const ± = measurement
 
 """
     measurement(val::Real, [err::Real]) -> Measurement
+    measurement(::Missing, [err::Union{Real,Missing}]) -> Missing
     val ± err -> Measurement
 
 Return a `Measurement` object with `val` as nominal value and `err` as
@@ -102,6 +103,8 @@ uncertainty.  `err` defaults to 0 if omitted.
 
 The binary operator `±` is equivalent to `measurement`, so you can construct a
 `Measurement` object by explicitely writing `123 ± 4`.
+
+If `val` is `missing`, `missing` is returned.
 """
 measurement
 

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -90,6 +90,7 @@ function measurement(val::T, err::T) where {T<:AbstractFloat}
     end
 end
 measurement(val::Real, err::Real) = measurement(promote(float(val), float(err))...)
+measurement(::Missing, ::Union{Real,Missing} = missing) = missing
 const ± = measurement
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,10 +44,20 @@ end
     @test typeof(@inferred(Measurement{Float64}(big"3.14"))) == Measurement{Float64}
     @test typeof(@inferred(Measurement{BigFloat}(-5.43f2))) == Measurement{BigFloat}
     @test x != pi != y
+end
+
+@testset "missing values" begin
     @test measurement(missing) === missing
     @test measurement(missing, .1) === missing
     @test measurement(missing, missing) === missing
     @test_throws MethodError measurement(1, missing)
+
+    @test promote_type(Measurement{Float64}, Missing) == Union{Measurement{Float64},Missing}
+    @test [w, x, missing, y] isa Vector{Union{Measurement{Float64},Missing}}
+
+    for op in (+, -, *, /, ^)
+        @test op(w, missing) === op(missing, w) === missing
+    end
 end
 
 @testset "Weighted Average" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,10 @@ end
     @test typeof(@inferred(Measurement{Float64}(big"3.14"))) == Measurement{Float64}
     @test typeof(@inferred(Measurement{BigFloat}(-5.43f2))) == Measurement{BigFloat}
     @test x != pi != y
+    @test measurement(missing) === missing
+    @test measurement(missing, .1) === missing
+    @test measurement(missing, missing) === missing
+    @test_throws MethodError measurement(1, missing)
 end
 
 @testset "Weighted Average" begin


### PR DESCRIPTION
I found this quite useful to have when dealing with real data. I intentionally didn't define `measurement(::Real, ::Missing)`, as here it isn't exactly clear what the result should be, so it's probably better to leave this up to the user to handle.

Fix #59.