### PR TITLE
Make `nextfloat` return a `Measurement` object

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,6 @@
 History of Measurements.jl
 ==========================
 
-v2.1.1 (2019-08-05)
--------------------
-
-### Bug Fixes
-
-* Fix loading of `SpecialFunctions.jl`
-  ([#49](https://github.com/JuliaPhysics/Measurements.jl/issues/49),
-  [#50](https://github.com/JuliaPhysics/Measurements.jl/pull/50)).
-
 v2.2.0 (2020-xx-xx)
 -------------------
 
@@ -19,6 +10,23 @@ v2.2.0 (2020-xx-xx)
   `measurement(missing, missing)` will now return `missing`
   ([#59](https://github.com/JuliaPhysics/Measurements.jl/issues/59),
   [#62](https://github.com/JuliaPhysics/Measurements.jl/pull/62))
+
+### Bug Fixes
+
+* `nextfloat(x::Measurement{T})` and `prevfloat(x::Measurement{T})` now return
+  an object of type `Measurement{T}` with the same uncertainty as `x`, instead
+  of returning an object of type
+  `T`. ([#64](https://github.com/JuliaPhysics/Measurements.jl/issues/64),
+  [#65](https://github.com/JuliaPhysics/Measurements.jl/pull/65))
+
+v2.1.1 (2019-08-05)
+-------------------
+
+### Bug Fixes
+
+* Fix loading of `SpecialFunctions.jl`
+  ([#49](https://github.com/JuliaPhysics/Measurements.jl/issues/49),
+  [#50](https://github.com/JuliaPhysics/Measurements.jl/pull/50)).
 
 v2.1.0 (2019-08-03)
 -------------------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Measurements"
 uuid = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 authors = ["Mosè Giordano <mose@gnu.org>"]
-version = "2.1.1"
+version = "2.2.0"
 
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"

--- a/src/math.jl
+++ b/src/math.jl
@@ -710,8 +710,8 @@ Base.rem2pi(a::Measurement, r::RoundingMode) = result(rem2pi(a.val, r), 1, a)
 Base.eps(::Type{Measurement{T}}) where {T<:AbstractFloat} = eps(T)
 Base.eps(a::Measurement) = eps(a.val)
 
-Base.nextfloat(a::Measurement) = nextfloat(a.val)
-Base.nextfloat(a::Measurement, n::Integer) = nextfloat(a.val, n)
+Base.nextfloat(a::Measurement) = result(nextfloat(a.val), 1, a)
+Base.nextfloat(a::Measurement, n::Integer) = result(nextfloat(a.val, n), 1, a)
 
 Base.maxintfloat(::Type{Measurement{T}}) where {T<:AbstractFloat} = maxintfloat(T)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -536,8 +536,10 @@ end
 @testset "Machine precisionx" begin
     @test eps(Measurement{Float64}) ≈ eps(Float64)
     @test eps(x) ≈ eps(x.val)
-    @test nextfloat(x) ≈ nextfloat(x.val)
-    @test nextfloat(x, 3) ≈ nextfloat(x.val, 3)
+    @test nextfloat(x) ≈ nextfloat(x.val) ± x.err
+    @test nextfloat(x, 3) ≈ nextfloat(x.val, 3) ± x.err
+    @test prevfloat(w) ≈ prevfloat(w.val) ± w.err
+    @test prevfloat(y, 3) ≈ prevfloat(y.val, 3) ± y.err
     @test maxintfloat(Measurement{Float64}) ≈ maxintfloat(Float64)
 end
 


### PR DESCRIPTION
Fix #64.  CC: @MartinOtter