### PR TITLE
Add methods for floatmin/floatmax

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -715,8 +715,8 @@ Base.nextfloat(a::Measurement, n::Integer) = result(nextfloat(a.val, n), 1, a)
 
 Base.maxintfloat(::Type{Measurement{T}}) where {T<:AbstractFloat} = maxintfloat(T)
 
-Base.floatmin(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmin(T)
-Base.floatmax(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmax(T)
+Base.floatmin(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmin(T) ± zero(T)
+Base.floatmax(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmax(T) ± zero(T)
 
 Base.typemax(::Type{Measurement{T}}) where {T<:AbstractFloat} = typemax(T)
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -715,6 +715,9 @@ Base.nextfloat(a::Measurement, n::Integer) = result(nextfloat(a.val, n), 1, a)
 
 Base.maxintfloat(::Type{Measurement{T}}) where {T<:AbstractFloat} = maxintfloat(T)
 
+Base.floatmin(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmin(T)
+Base.floatmax(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmax(T)
+
 Base.typemax(::Type{Measurement{T}}) where {T<:AbstractFloat} = typemax(T)
 
 ### Rounding

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -533,15 +533,15 @@ end
     end
 end
 
-@testset "Machine precisionx" begin
+@testset "Machine precision" begin
     @test eps(Measurement{Float64}) ≈ eps(Float64)
     @test eps(x) ≈ eps(x.val)
     @test nextfloat(x) ≈ nextfloat(x.val) ± x.err
     @test nextfloat(x, 3) ≈ nextfloat(x.val, 3) ± x.err
     @test prevfloat(w) ≈ prevfloat(w.val) ± w.err
     @test prevfloat(y, 3) ≈ prevfloat(y.val, 3) ± y.err
-    @test floatmin(Measurement{Float64}) ≈ floatmin(Float64)
-    @test floatmax(Measurement{Float64}) ≈ floatmax(Float64)
+    @test floatmin(Measurement{Float64}) ≈ floatmin(Float64) ± zero(Float64)
+    @test floatmax(Measurement{Float64}) ≈ floatmax(Float64) ± zero(Float64)
     @test maxintfloat(Measurement{Float64}) ≈ maxintfloat(Float64)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -540,6 +540,8 @@ end
     @test nextfloat(x, 3) ≈ nextfloat(x.val, 3) ± x.err
     @test prevfloat(w) ≈ prevfloat(w.val) ± w.err
     @test prevfloat(y, 3) ≈ prevfloat(y.val, 3) ± y.err
+    @test floatmin(Measurement{Float64}) ≈ floatmin(Float64)
+    @test floatmax(Measurement{Float64}) ≈ floatmax(Float64)
     @test maxintfloat(Measurement{Float64}) ≈ maxintfloat(Float64)
 end
 


### PR DESCRIPTION
I ran into a missing method error when curve-fitting a vector of Measurements using Polynomials.jl:
```
julia> using Measurements, Polynomials, GenericLinearAlgebra

julia> fit([1, 2], (rand(2) .± rand(2)), 1)
ERROR: MethodError: no method matching floatmin(::Type{Measurement{Float64}})
Closest candidates are:
  floatmin() at float.jl:776
  floatmin(::Type{Float16}) at float.jl:738
  floatmin(::Type{Float32}) at float.jl:739
```
Fixed with
```
Base.floatmin(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmin(T)
Base.floatmax(::Type{Measurement{T}}) where {T<:AbstractFloat} = floatmax(T)
```