### PR TITLE
Loosen signature of `value` and `uncertainty` for `Unitful`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,27 @@
 # History of Measurements.jl
 
+## v2.5.0 (2021-01-28)
+
+### New features
+
+* When the package `Unitful.jl` is loaded, now `Measurements.value` and
+  `Measurements.uncertainty` accept any `AbstractQuantity`, instead of only
+  `AbstractQuantity{<:Measurement}`
+  ([#87](https://github.com/JuliaPhysics/Measurements.jl/issues/87),
+  [#88](https://github.com/JuliaPhysics/Measurements.jl/issues/88)).
+
 ## v2.4.0 (2021-01-20)
 
 ### New features
 
-* New method for `sincospi(::Measurement)`, when `sincospi` is defined.
+* New method for `sincospi(::Measurement)`, when `sincospi` is defined
+  ([#76](https://github.com/JuliaPhysics/Measurements.jl/pull/76)).
 
 ### Bug Fixes
 
-* Numbers with infinite error are shown correctly.
+* Numbers with infinite error are shown correctly
+  ([#83](https://github.com/JuliaPhysics/Measurements.jl/pull/83),
+  [#84](https://github.com/JuliaPhysics/Measurements.jl/pull/84)).
 
 v2.3.0 (2020-09-08)
 -------------------
@@ -16,7 +29,8 @@ v2.3.0 (2020-09-08)
 ### New features
 
 * New methods for `floatmin(::Type{Measurement})` and
-  `floatmax(::Type{Measurement})`.
+  `floatmax(::Type{Measurement})`
+  ([#72](https://github.com/JuliaPhysics/Measurements.jl/pull/72)).
 
 v2.2.1 (2020-05-21)
 -------------------
@@ -24,6 +38,7 @@ v2.2.1 (2020-05-21)
 ### Minor Changes
 
 * Allow installation of new versions of `RecipesBase.jl`
+  ([#70](https://github.com/JuliaPhysics/Measurements.jl/pull/70)).
 
 v2.2.0 (2020-02-02)
 -------------------

--- a/src/unitful.jl
+++ b/src/unitful.jl
@@ -24,12 +24,12 @@ Measurements.measurement(a::AbstractQuantity{T1,D,U1},
                          b::AbstractQuantity{T2,D,U2}) where {T1,T2,D,U1,U2} =
                              measurement(promote(a, b)...)
 
-function Measurements.value(x::AbstractQuantity{<:Measurement})
+function Measurements.value(x::AbstractQuantity)
     u = unit(x)
     return value(ustrip(u, x)) * u
 end
 
-function Measurements.uncertainty(x::AbstractQuantity{<:Measurement})
+function Measurements.uncertainty(x::AbstractQuantity)
     u = unit(x)
     return uncertainty(ustrip(u, x)) * u
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -805,6 +805,11 @@ end
     x = 1u"m" ± .2u"m"
     @test value(x) == 1u"m"
     @test uncertainty(x) == .2u"m"
+
+    # `value` and `uncertainty` should work on any AbstractQuantity
+    x = 2.71u"m/s"
+    @test value(x) == x
+    @test uncertainty(x) == zero(x)
 end
 
 @testset "Complex measurements" begin


### PR DESCRIPTION
Fix #87.