### PR TITLE
make measurements work with at-printf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "2.5.0"
 [deps]
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -24,6 +24,8 @@ module Measurements
 # Calculus is used to calculate numerical derivatives in "@uncertain" macro.
 using Calculus
 
+import Printf
+
 using Requires
 
 # Functions provided by this package and exposed to users

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -24,8 +24,6 @@ module Measurements
 # Calculus is used to calculate numerical derivatives in "@uncertain" macro.
 using Calculus
 
-import Printf
-
 using Requires
 
 # Functions provided by this package and exposed to users

--- a/src/show.jl
+++ b/src/show.jl
@@ -15,6 +15,8 @@
 #
 ### Code:
 
+import Printf
+
 function truncated_print(io::IO, m::Measurement, error_digits::Int;
                          atbeg = "", atend = "", pm = "±")
     val = if iszero(m.err) || !isfinite(m.err)

--- a/src/show.jl
+++ b/src/show.jl
@@ -88,6 +88,10 @@ function Base.alignment(io::IO, measure::Measurement)
         (length(m.captures[1]), length(m.captures[2]))
 end
 
+if VERSION >= v"1.6.0-rc1"
+    Printf.tofloat(measure::Measurement) = Printf.tofloat(measure.val)
+end
+
 ### Juno pretty printing
 @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" begin
     Juno.render(i::Juno.Inline, measure::Measurement) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Measurements, SpecialFunctions, QuadGK, Calculus
-using Test, LinearAlgebra, Statistics, Unitful
+using Test, LinearAlgebra, Statistics, Unitful, Printf
 
 import Base: isapprox
 import Measurements: value, uncertainty
@@ -628,6 +628,15 @@ end
         # the same number (note that the tag will be different, but that's not important here).
         for a in (w, x, y); @test eval(Meta.parse(repr(a))) == a; end
     end
+    if VERSION >= v"1.6.0-rc1"
+        @testset "@printf" begin
+            for T in (Float16, Float32, Float64, BigFloat)
+                m1 = measurement(one(T))
+                @test_nowarn @printf("Testing @printf: %.2e\n", m1)
+                @test @sprintf("Testing @sprintf: %.2e\n", m1) == "Testing @sprintf: 1.00e+00\n"
+            end
+        end
+    end
 end
 
 @testset "sum" begin
@@ -851,7 +860,7 @@ end
     @test m .* (1:2:6) isa StepRangeLen
     @test (1:.1:6) .- m isa StepRangeLen
     @test m ./ (1:6.0) isa Vector{<:Measurement}
-    
+
     # JuliaLang/julia#30944
     @test range(0±0, step=1±.1, length=10) isa StepRangeLen
 end


### PR DESCRIPTION
I implemented specializations of `Printf.tofloat` to allow printing (the value of) `Measurement`s. This is useful when working with functions that print some information during the computation, cf. https://discourse.julialang.org/t/forwarddiff-jl-and-printf/57694. This approach is also used in ForwardDiff.jl, cf. https://github.com/JuliaDiff/ForwardDiff.jl/pull/511.

The basic reasoning for this is that `Measurement`'s identify as `AbstractFloat`s, which are `Real`s. Hence, they can (and will) be used in quite general contexts where real numbers can appear. If someone implements a numerical algorithm in generic Julia code that can take quite some time and does not need to make use of Measurements.jl directly, they might have some intermediate printing statements to inform the user about the progress. Hence, it would be really nice if `Measurement`s could still be used within such generic code written for `Real` numbers.

Closes #101