### PR TITLE
Use atomic tag counter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # History of Measurements.jl
 
+## v2.8.0 (2022-09-01)
+
+### New features
+
+* The counter of the tags of `Measurement` objects is now atomic
+  ([#118](https://github.com/JuliaPhysics/Measurements.jl/pull/118)).
+
 ## v2.7.2 (2022-05-21)
 
 ### Bug Fixes

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -77,9 +77,10 @@ end
 @generated empty_der1(x::Measurement{T}) where {T<:AbstractFloat} = Derivatives{T}()
 @generated empty_der2(x::T) where {T<:AbstractFloat} = Derivatives{x}()
 
-function __init__()
-    task_local_storage("measurementsjl-tag", 1)
+# Start from 1, 0 is reserved to derived quantities
+const tag_counter = Threads.Atomic{UInt64}(1)
 
+function __init__()
     @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" include("unitful.jl")
     @require QuadGK="1fd47b50-473d-5c70-9696-f719f8f3bcdc" include("quadgk.jl")
     @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" include("special-functions.jl")
@@ -93,7 +94,7 @@ function measurement(val::T, err::T) where {T<:AbstractFloat}
     if iszero(err)
         Measurement{T}(val, err, UInt64(0), newder)
     else
-        @inbounds tag = task_local_storage("measurementsjl-tag", task_local_storage("measurementsjl-tag") + 1)
+        tag = Threads.atomic_add!(tag_counter, UInt64(1))
         return Measurement{T}(val, err, tag, Derivatives(newder, (val, err, tag)=>one(T)))
     end
 end


### PR DESCRIPTION
I need think more about this, but this doesn't look good at all
performance-wise.  Before PR:

```
julia> @benchmark measurement(1, 2,)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):   7.706 ns …  1.856 μs  ┊ GC (min … max):  0.00% … 99.28%
 Time  (median):      9.483 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   12.307 ns ± 43.490 ns  ┊ GC (mean ± σ):  10.97% ±  3.13%

  ▄▅▃▂██▅▃▂▁                           ▁ ▁▂▂▁▁                ▂
  ███████████▇▆▅▆▅▆▅▅▅▅▆▄▄▃▄▄▃▄▅▅▅▆▇▇██████████▆▆▄▆▆▅▆▆▆▆▆▆▆▅ █
  7.71 ns      Histogram: log(frequency) by time        28 ns <

 Memory estimate: 48 bytes, allocs estimate: 1.
```

After PR:

```
julia> @benchmark measurement(1, 2)
BenchmarkTools.Trial: 10000 samples with 192 evaluations.
 Range (min … max):  511.146 ns …  19.476 μs  ┊ GC (min … max): 0.00% … 96.25%
 Time  (median):     544.625 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   577.264 ns ± 528.867 ns  ┊ GC (mean ± σ):  2.86% ±  3.05%

  ▆▅▆▆▆█▅▃▂▂▂▃▂▂▂▂▃▃▁▁▁▂▁                                       ▂
  █████████████████████████▇▇█▇█▇▇▇▆▇▇▇▇█▇▇▆▅▆▆▆▇▆▄▃▄▅▆▅▆▅▅▆▄▁▅ █
  511 ns        Histogram: log(frequency) by time        908 ns <

 Memory estimate: 256 bytes, allocs estimate: 9.
```

I'm not really convinced it's worth killing performance this badly, the tag has
a very minor role.

Also the benchmarks run in this PR confirm the bad effect on performance: https://github.com/JuliaPhysics/Measurements.jl/blob/3191a32b3043eb15d120de82371b2cfab33b077e/2022/03/28/214322/result.md#results