### PR TITLE
Fix a few typos in README and docs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If you use use this package for your research, please cite it.
 The complete manual of `Measurements.jl` is available at
 https://juliaphysics.github.io/Measurements.jl/stable/.  There, people
 interested in the details of the package, in order integrate the package in
-their workflow, can can find a technical appendix explaining how the package
+their workflow, can find a technical appendix explaining how the package
 internally works.
 
 Installation

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -161,7 +161,7 @@ Measurements.uncertainty_components
 
 You may want to inspect which measurement contributes most to the total
 uncertainty of a derived quantity, in order to minimize it, if possible.  The
-function `Measurements.uncertainty_components` gives you a dictonary whose
+function `Measurements.uncertainty_components` gives you a dictionary whose
 values are the components of the uncertainty of `x`.
 
 Standard Score
@@ -200,7 +200,7 @@ Measurements.uncertainty
 
 As explained in the technical appendix, the nominal value and the uncertainty of
 `Measurement` objects are stored in `val` and `err` fields respectively, but you
-do not need to use those field directly to access this information. Functions
+do not need to use those fields directly to access this information. Functions
 `Measurements.value` and `Measurements.uncertainty` allow you to get the nominal
 value and the uncertainty of `x`, be it a single measurement or an array of
 measurements. They are particularly useful in the case of complex measurements


### PR DESCRIPTION
I've just fixed a few typos in the README file and the documentation. 

Thank you very much for the development and maintenance of this very useful package! 