### PR TITLE
[GHA] Use newer workflows and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,22 +4,21 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.8.5'
-      - name: Cache artifacts
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.julia/artifacts
-            ~/.julia/registries
-          key: ${{ runner.os }}-benchmarks-artifacts-${{ hashFiles('**/Project.toml') }}
-          restore-keys: ${{ runner.os }}-benchmarks-artifacts
+      - uses: julia-actions/cache@v1
       - name: Run benchmarks
         shell: julia --color=yes --project=benchmark {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
   release:
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: always.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Julia ${{ matrix.julia-version }} - ${{ matrix.os }} - ${{ matrix.julia-arch }}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -5,3 +5,10 @@ Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
+
+[compat]
+BenchmarkCI = "0.1"
+BenchmarkTools = "1"
+PkgBenchmark = "0.2"
+QuadGK = "2"
+SpecialFunctions = "2"


### PR DESCRIPTION
Remove manifest, and automatically develop the package when running the
benchmarks, similarly to what happens when building the docs.