### PR TITLE
Makie.jl extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ julia = "1"
 
 [extensions]
 MeasurementsJunoExt = "Juno"
+MeasurementsMakieExt = "Makie"
 MeasurementsRecipesBaseExt = "RecipesBase"
 MeasurementsSpecialFunctionsExt = "SpecialFunctions"
 MeasurementsUnitfulExt = "Unitful"
@@ -26,6 +27,7 @@ MeasurementsUnitfulExt = "Unitful"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
@@ -38,6 +40,7 @@ test = ["Aqua", "QuadGK", "RecipesBase", "SpecialFunctions", "Statistics", "Test
 
 [weakdeps]
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/ext/MeasurementsMakieExt.jl
+++ b/ext/MeasurementsMakieExt.jl
@@ -46,3 +46,4 @@ Makie.convert_arguments(P::Type{<:Band}, x::AbstractVector{<:Real}, y::AbstractV
     convert_arguments(P, x, value.(y) - uncertainty.(y), value.(y) + uncertainty.(y)) 
 
 end #module
+

--- a/ext/MeasurementsMakieExt.jl
+++ b/ext/MeasurementsMakieExt.jl
@@ -1,7 +1,5 @@
 ### plot-recipes.jl
 #
-# Copyright (C) 2017 Mosè Giordano.
-#
 # Maintainer: Mosè Giordano <mose AT gnu DOT org>
 # Keywords: uncertainty, error propagation, physics, plots
 #
@@ -46,4 +44,3 @@ Makie.convert_arguments(P::Type{<:Band}, x::AbstractVector{<:Real}, y::AbstractV
     convert_arguments(P, x, value.(y) - uncertainty.(y), value.(y) + uncertainty.(y)) 
 
 end #module
-

--- a/ext/MeasurementsMakieExt.jl
+++ b/ext/MeasurementsMakieExt.jl
@@ -1,0 +1,48 @@
+### plot-recipes.jl
+#
+# Copyright (C) 2017 Mosè Giordano.
+#
+# Maintainer: Mosè Giordano <mose AT gnu DOT org>
+# Keywords: uncertainty, error propagation, physics, plots
+#
+# This file is a part of Measurements.jl.
+#
+# License is MIT "Expat".
+#
+### Commentary:
+#
+# This file defines the recipes to plot Measurements vectors with Makie.jl package in 2D.
+#
+### Code:
+module MeasurementsMakieExt
+
+if isdefined(Base, :get_extension)
+    using Measurements: Measurement, value, uncertainty
+    using Makie: Makie, PointBased, Errorbars, Band
+else
+    using ..Measurements: Measurement, value, uncertainty
+    using ..Makie: Makie, PointBased, Errorbars, Band
+end
+# PointBased plots
+Makie.convert_arguments(P::PointBased, x::AbstractVector{<:Measurement}, y::AbstractVector{<:Measurement}) =
+    convert_arguments(P, value.(x), value.(y))
+Makie.convert_arguments(P::PointBased, x::AbstractVector{<:Real}, y::AbstractVector{<:Measurement}) =
+    convert_arguments(P, x, value.(y))
+Makie.convert_arguments(P::PointBased, x::AbstractVector{<:Measurement}, y::AbstractVector{<:Real}) =
+    convert_arguments(P, value.(x), y)
+
+# errorbars
+Makie.convert_arguments(P::Type{<:Errorbars}, x::AbstractVector{<:Measurement}, y::AbstractVector{<:Measurement}, e::AbstractVector{<:Measurement}) =
+    convert_arguments(P, value.(x), value.(y), uncertainty.(e))
+Makie.convert_arguments(P::Type{<:Errorbars}, x::AbstractVector{<:Measurement}, y::AbstractVector{<:Real}) =
+    convert_arguments(P, value.(x), y, uncertainty.(x))
+Makie.convert_arguments(P::Type{<:Errorbars}, x::AbstractVector{<:Real}, y::AbstractVector{<:Measurement}) =
+    convert_arguments(P, x, value.(y), uncertainty.(y))
+
+# band
+Makie.convert_arguments(P::Type{<:Band}, x::AbstractVector{<:Measurement}, y::AbstractVector{<:Measurement}) =
+    convert_arguments(P, value.(x), value.(y) - uncertainty.(y), value.(y) + uncertainty.(y))
+Makie.convert_arguments(P::Type{<:Band}, x::AbstractVector{<:Real}, y::AbstractVector{<:Measurement}) =
+    convert_arguments(P, x, value.(y) - uncertainty.(y), value.(y) + uncertainty.(y)) 
+
+end #module

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -133,7 +133,6 @@ end
         @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" include("../ext/MeasurementsUnitfulExt.jl")
         @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" include("../ext/MeasurementsSpecialFunctionsExt.jl")
         @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" include("../ext/MeasurementsJunoExt.jl")
-        @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("../ext/MeasurementsMakieExt.jl")
     end
 end
 

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -133,6 +133,7 @@ end
         @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" include("../ext/MeasurementsUnitfulExt.jl")
         @require SpecialFunctions="276daf66-3868-5448-9aa4-cd146d93841b" include("../ext/MeasurementsSpecialFunctionsExt.jl")
         @require Juno="e5e0dc1b-0480-54bc-9374-aad01c23163d" include("../ext/MeasurementsJunoExt.jl")
+        @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("../ext/MeasurementsMakieExt.jl")
     end
 end
 


### PR DESCRIPTION
Based on #123 . but using the 1.9 extensions mechanism. should solve #95, https://github.com/MakieOrg/Makie.jl/issues/875 . Tests missing. (just call `Makie.convert_arguments`, it seems)
