### PR TITLE
More `Unitful` support 

### DIFF
--- a/ext/MeasurementsUnitfulExt.jl
+++ b/ext/MeasurementsUnitfulExt.jl
@@ -46,4 +46,9 @@ function Measurements.uncertainty(x::AbstractQuantity)
     return uncertainty(ustrip(u, x)) * u
 end
 
+function Measurements.stdscore(a::AbstractQuantity{Measurement{T1},D,U1}, b::AbstractQuantity{T2,D,U2}) where {T1<:AbstractFloat,T2<:Real,D,U1,U2}
+    u = unit(a)
+    return stdscore(ustrip(u, a), ustrip(u, b)) # unitless quantity.
+end
+
 end

--- a/ext/MeasurementsUnitfulExt.jl
+++ b/ext/MeasurementsUnitfulExt.jl
@@ -51,6 +51,13 @@ function Measurements.stdscore(a::AbstractQuantity{Measurement{T1},D,U1}, b::Abs
     return stdscore(ustrip(u, a), ustrip(u, b)) # unitless quantity.
 end
 
+function Measurements.derivative(a::AbstractQuantity{Measurement{T1},D1,U1}, b::AbstractQuantity{Measurement{T2},D2,U2}) where {T1<:AbstractFloat,T2<:AbstractFloat,D1,D2,U1,U2}
+    u_a = unit(a)
+    u_b = unit(b)
+    u_der = u_a / u_b
+    return Measurements.derivative(ustrip(u_a, a), ustrip(u_b, b)) * u_der
+end
+
 function Measurements.uncertainty_components(a::AbstractQuantity{Measurement{T},D,U}) where {T<:AbstractFloat,D,U}
     u = unit(a)
     return Measurements.uncertainty_components(ustrip(u, a))

--- a/ext/MeasurementsUnitfulExt.jl
+++ b/ext/MeasurementsUnitfulExt.jl
@@ -51,4 +51,10 @@ function Measurements.stdscore(a::AbstractQuantity{Measurement{T1},D,U1}, b::Abs
     return stdscore(ustrip(u, a), ustrip(u, b)) # unitless quantity.
 end
 
+function Measurements.uncertainty_components(a::AbstractQuantity{Measurement{T},D,U}) where {T<:AbstractFloat,D,U}
+    u = unit(a)
+    return Measurements.uncertainty_components(ustrip(u, a))
+    # We've lost units :(
+end
+
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -31,8 +31,8 @@ Return the weighted mean of measurements listed in `iterable`, using
 inverse-variance weighting.  NOTA BENE: correlation is not taken into account.
 """
 function weightedmean(iterable)
-    v = [el.val for el in iterable]
-    w = [inv(el.err)^2 for el in iterable]
+    v = [value(el) for el in iterable]
+    w = [inv(uncertainty(el))^2 for el in iterable]
     invsumw = inv(sum(w))
     return measurement(dot(v, w)*invsumw, sqrt(invsumw))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,14 @@ end
     c = 1 ± 0
     @test @inferred(Measurements.derivative(3*x^2, (x.val, x.err, x.tag))) ≈ 18
     @test @inferred(Measurements.derivative(3*x^2, x)) ≈ 18
+    @test @inferred(Measurements.derivative(3*u"s"*x*u"m", x*u"m")) ≈ 3*u"s"
+    @test uconvert(u"s", @inferred(Measurements.derivative(3*u"s"*x*u"cm", x*u"m"))) ≈ (3/100)*u"s"
+    @test uconvert(u"s", @inferred(Measurements.derivative(3*u"s"*x*u"m", x*u"cm"))) ≈ (3*100)*u"s"
+    @test uconvert(u"m*s", @inferred(Measurements.derivative(3*u"s"*(x*u"cm")^2, x*u"m"))) ≈ (18 / 10000)*u"m*s"
+    @test uconvert(u"m*s", @inferred(Measurements.derivative(3*u"s"*(x*u"m")^2, x*u"cm"))) ≈ (18 * 100)*u"m*s" # FIXME: should be 18/100
+    @test @inferred(Measurements.derivative(3*u"s"/(x*u"m"), x*u"m")) ≈ (-1/3)*u"s"/1u"m^2"
+    @test @inferred(Measurements.derivative(3*u"s"*x*u"V", x*u"m")) ≈ 3*u"s"*u"V"/1u"m"
+    @test Measurements.derivative.(2*u"s"*x*u"m" + 1*u"s"*y*u"m", [x*u"m", y*u"m"]) ≈ [2*u"s", 1*u"s"]
     @test Measurements.derivative.(2x + y - w, [x, y, w]) ≈ [2, 1, -1]
     @test Measurements.derivative.(x - x + y - y + w - w + c, [x, y, w, c]) ≈ [0, 0, 0, 0]
     @test length((x - x + y - y + w - w + c).der) == 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,8 @@ end
 
 @testset "Weighted Average" begin
     @test @inferred(weightedmean((w, x, y))) ≈ measurement(-0.12584269662921355, 0.028442727788398632)
+    @test @inferred(weightedmean((w*u"m", x*u"m", y*u"m"))) ≈ measurement(-0.12584269662921355, 0.028442727788398632) * u"m"
+    @test (weightedmean((w*u"m", 100*x*u"cm", y*u"m"))) ≈ measurement(-0.12584269662921355, 0.028442727788398632) * u"m"
 end
 
 @testset "Derivative" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,6 +210,12 @@ end
 @testset "Contributions to uncertainty" begin
     @test sort(collect(values(@inferred(Measurements.uncertainty_components(w * x * y))))) ≈
         [0.2, 0.3, 0.36]
+
+    w_d = w * u"W/cm"
+    x_d = x * u"cm"
+    y_d = y * u"s"
+    @test sort(collect(values(@inferred(Measurements.uncertainty_components(w_d * x_d * y_d))))) ≈
+        [0.2, 0.3, 0.36]
 end
 
 @testset "Conversion and Promotion" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,12 @@ z = complex(x)
     @test @inferred(stdscore(x, y)) ≈ -4.472135954999579
     @test @inferred(stdscore(w, y)) ≈ @inferred(stdscore(w - y, 0))
     @test @inferred(stdscore(y, 4.1)) ≈ @inferred(stdscore(y, 4.1 ± 0))
+    @test @inferred(stdscore(w*u"m", x.val*u"m")) ≈ -350/3
+    @test @inferred(stdscore(w*u"m", 100*x.val*u"cm")) ≈ -350/3
+    @test_throws MethodError @inferred(stdscore(w*u"m", x.val*u"s"))
+    @test @inferred(stdscore(x*u"m", y*u"m")) ≈ -4.472135954999579
+    @test @inferred(stdscore(x*u"m", 100*y*u"cm")) ≈ -4.472135954999579
+    @test_throws MethodError @inferred(stdscore(x*u"m", y*u"s"))
 end
 
 @testset "measurement" begin


### PR DESCRIPTION
As noted in https://github.com/JuliaPhysics/Measurements.jl/issues/151,
the functionality provided in `utils.jl` does not support `Unitful` `Measuremets`.

I'm not 100% sure about the unit handling in `derivative`.

I don't think `uncertainty_components` can properly support units,
since derivatives only track `Measuremet`s, after stripping `AbstractQuantity`...

TODO: `cov`/`cor`/`correlated_values`.