### PR TITLE
Declare base numeric type to BaseType.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mosè Giordano <mose@gnu.org>"]
 version = "2.10.0"
 
 [deps]
+BaseType = "7fbed51b-1ef5-4d67-9085-a4a9b26f478c"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
@@ -23,6 +24,7 @@ MeasurementsSpecialFunctionsExt = "SpecialFunctions"
 MeasurementsUnitfulExt = "Unitful"
 
 [compat]
+BaseType = "0.2"
 Calculus = "0.4.1, 0.5"
 RecipesBase = "0.6.0, 0.7, 0.8, 1.0"
 Requires = "0.5.0, 1"
@@ -30,6 +32,7 @@ julia = "1"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BaseType = "7fbed51b-1ef5-4d67-9085-a4a9b26f478c"
 Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
@@ -39,4 +42,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "QuadGK", "RecipesBase", "SpecialFunctions", "Statistics", "Test", "Unitful"]
+test = ["Aqua", "BaseType", "QuadGK", "RecipesBase", "SpecialFunctions", "Statistics", "Test", "Unitful"]

--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -24,6 +24,9 @@ module Measurements
 # Calculus is used to calculate numerical derivatives in "@uncertain" macro.
 using Calculus
 
+# Declare the base numeric type for interfaces (e.g., QuadGK)
+using BaseType: BaseType, base_numeric_type
+
 # Functions provided by this package and exposed to users
 export Measurement, measurement, ±
 
@@ -108,6 +111,8 @@ The binary operator `±` is equivalent to `measurement`, so you can construct a
 If `val` is `missing`, `missing` is returned.
 """
 measurement
+
+BaseType.base_numeric_type(::Type{<:Measurement{T}}) where {T} = base_numeric_type(T)
 
 include("conversions.jl")
 include("comparisons-tests.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Measurements, SpecialFunctions, QuadGK, Calculus
+using Measurements, SpecialFunctions, QuadGK, Calculus, BaseType
 using Test, LinearAlgebra, Statistics, Unitful, Printf, Aqua
 
 if !isdefined(Base,:get_extension)
@@ -1059,4 +1059,17 @@ end
 
     # JuliaLang/julia#30944
     @test range(0±0, step=1±.1, length=10) isa StepRangeLen
+end
+
+@testset "Base type" begin
+    for T in (Float16, Float32, Float64)
+        x = Measurement{T}(1.0)
+        @test base_numeric_type(x) == T
+        @test base_numeric_type(typeof(x)) == T
+
+        # Should still work for nested types:
+        nested_x = x * u"m"
+        @test base_numeric_type(x) == T
+        @test base_numeric_type(typeof(x)) == T
+    end
 end


### PR DESCRIPTION
BaseType.jl is an interface package that was introduced after a discussion about how to extract the base numeric type for some wrapper type. e.g., 

> @stevengj: There is no way to get the base scalar type from dimensionful types and similar (e.g. measurements, dual numbers) AFAIK using only Base functions

We came up with BaseType.jl to address this by declaring `base_numeric_type` that packages should overload to declare what the base scalar type is. (Eventually we want to put this in Base, but for now, it can be this lightweight interface package)

This PR does this for `Measurement{T} -> T`. For example,

```julia
base_numeric_type(Measurement{Float32}) == Float32
base_numeric_type(Unitful.Quantity{Measurement{Float32}}) == Float32
```

Since BaseType.jl is literally just an interface, I recommend putting it in `[deps]` rather than `[weakdeps]` as the former will have negligible effect on startup time, so no reason to create an entire extension for it.