### PR TITLE
Update MeasurementsJunoExt.jl

### DIFF
--- a/ext/MeasurementsJunoExt.jl
+++ b/ext/MeasurementsJunoExt.jl
@@ -29,8 +29,6 @@ end
 Juno.render(i::Juno.Inline, measure::Measurement) =
 Juno.render(i, Juno.Row(measure.val, Text(" ± "), measure.err))
 
-Juno.Row(measure.val, Text(" ± "), measure.err)
-
 function Juno.render(ji::Juno.Inline, cm::Complex{<:Measurement})
     r, i = reim(cm)
     if signbit(i) && !isnan(i)


### PR DESCRIPTION
there was an extra line of `Juno.Row`
that line was introduced in #14.

this is one option, the other would be to define `Juno.Row(measure::Measurement)`, but `Juno.Row` seems undocumented?