### PR TITLE
Add and test pairwise (scalar) `cov` and `cor` functions

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -116,10 +116,7 @@ function cov(x::AbstractVector{Measurement{T}}) where T
     covariance_matrix = zeros(T, (S, S))
 
     for (ii, i) = enumerate(eachindex(x)), (jj, j) = Iterators.take(enumerate(eachindex(x)), ii)
-        overlap = keys(x[i].der) ∩ keys(x[j].der)
-        covariance_matrix[ii, jj] = isempty(overlap) ? 0.0 : sum(overlap) do var
-            x[i].der[var] * x[j].der[var] * var[2]^2
-        end
+        covariance_matrix[ii, jj] = cov(x[i], x[j])
     end
 
     return Symmetric(covariance_matrix, :L)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -126,6 +126,18 @@ function cov(x::AbstractVector{Measurement{T}}) where T
 end
 
 """
+    Measurements.cov(a::Measurement, b::Measurement)
+
+Returns the (scalar) covariance between `Measurment`s `a` and `b`.
+"""
+function cov(a::Measurement{T}, b::Measurement{T}) where {T}
+    overlap = keys(a.der) ∩ keys(b.der)
+    return isempty(overlap) ? zero(T) : sum(overlap) do var
+        a.der[var] * b.der[var] * var[2]^2
+    end
+end
+
+"""
     Measurements.cor(x::AbstractVector{<:Measurement})
 
 Returns the correlation matrix of a vector of correlated `Measurement`s.
@@ -135,6 +147,13 @@ function cor(x::AbstractVector{<:Measurement})
     standard_deviations = sqrt.(diag(covariance_matrix))
     return covariance_matrix ./ standard_deviations ./ standard_deviations'
 end
+
+"""
+    Measurements.cor(a::Measurement, b::Measurement)
+
+Returns the (scalar) correlation between `Measurment`s `a` and `b`.
+"""
+cor(a::Measurement, b::Measurement) = cov(a,b)/(a.err*b.err)
 
 """
     Measurements.correlated_values(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,14 +96,14 @@ end
     y = -2x + 10
     z = -3x
     @test @inferred(Measurements.cov([x, y, z])) ≈ [0.01 -0.02 -0.03; -0.02 0.04 0.06; -0.03 0.06 0.09]
-    @test [@inferred(Measurements.cov(x,x)), @inferred(Measurements.cov(y,y)), @inferred(Measurements.cov(z,z))] ≈ [0.01, 0.04, 0.09]
+    @test [@inferred(Measurements.cov(x,x)), @inferred(Measurements.cov(y,y)), @inferred(Measurements.cov(z,z))] ≈ diag(Measurements.cov([x, y, z])) ≈ [0.01, 0.04, 0.09]
     @test [@inferred(Measurements.cov(x,y)), @inferred(Measurements.cov(y,z)), @inferred(Measurements.cov(x,z))] ≈ [-0.02, 0.06, -0.03]
 
     u = measurement(1, 0.05)
     v = measurement(10, 0.1)
     w = u + 2v
     @test @inferred(Measurements.cov([u, v, w])) ≈ [0.0025 0.0 0.0025; 0.0 0.01 0.02; 0.0025 0.02 0.0425]
-    @test [@inferred(Measurements.cov(u,u)), @inferred(Measurements.cov(v,v)), @inferred(Measurements.cov(w,w))] ≈ [0.0025, 0.01, 0.0425]
+    @test [@inferred(Measurements.cov(u,u)), @inferred(Measurements.cov(v,v)), @inferred(Measurements.cov(w,w))] ≈ diag(Measurements.cov([u, v, w])) ≈ [0.0025, 0.01, 0.0425]
     @test [@inferred(Measurements.cov(u,v)), @inferred(Measurements.cov(v,w)), @inferred(Measurements.cov(u,w))] ≈ [0.0, 0.02, 0.0025]
 end
 
@@ -113,6 +113,7 @@ end
     z = -3x
     @test @inferred(Measurements.cor([x, y, z])) ≈ [1.0 -1.0 -1.0; -1.0 1.0 1.0; -1.0 1.0 1.0]
     @test @inferred(Measurements.cor(x,x)) ≈ @inferred(Measurements.cor(y,y)) ≈ @inferred(Measurements.cor(z,z)) ≈ 1.0
+    @test [@inferred(Measurements.cor(x,x)), @inferred(Measurements.cor(y,y)), @inferred(Measurements.cor(z,z))] ≈ diag(Measurements.cor([x, y, z]))
     @test [@inferred(Measurements.cor(x,y)), @inferred(Measurements.cor(y,z)), @inferred(Measurements.cor(x,z))] ≈ [-1.0, 1.0, -1.0]
 
     u = measurement(1, 0.05)
@@ -120,6 +121,7 @@ end
     w = u + 2v
     @test @inferred(Measurements.cor([u, v, w])) ≈ [1.0 0.0 0.24253562503633297; 0.0 1.0 0.9701425001453319; 0.24253562503633297 0.9701425001453319 1.0] atol=1e-15
     @test @inferred(Measurements.cor(u,u)) ≈ @inferred(Measurements.cor(v,v)) ≈ @inferred(Measurements.cor(w,w)) ≈ 1.0
+    @test [@inferred(Measurements.cor(u,u)), @inferred(Measurements.cor(v,v)), @inferred(Measurements.cor(w,w))] ≈ diag(Measurements.cor([u, v, w]))
     @test [@inferred(Measurements.cor(u,v)), @inferred(Measurements.cor(v,w)), @inferred(Measurements.cor(u,w))] ≈ [0.0, 0.9701425001453319, 0.24253562503633297]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -96,11 +96,15 @@ end
     y = -2x + 10
     z = -3x
     @test @inferred(Measurements.cov([x, y, z])) ≈ [0.01 -0.02 -0.03; -0.02 0.04 0.06; -0.03 0.06 0.09]
+    @test [@inferred(Measurements.cov(x,x)), @inferred(Measurements.cov(y,y)), @inferred(Measurements.cov(z,z))] ≈ [0.01, 0.04, 0.09]
+    @test [@inferred(Measurements.cov(x,y)), @inferred(Measurements.cov(y,z)), @inferred(Measurements.cov(x,z))] ≈ [-0.02, 0.06, -0.03]
 
     u = measurement(1, 0.05)
     v = measurement(10, 0.1)
     w = u + 2v
     @test @inferred(Measurements.cov([u, v, w])) ≈ [0.0025 0.0 0.0025; 0.0 0.01 0.02; 0.0025 0.02 0.0425]
+    @test [@inferred(Measurements.cov(u,u)), @inferred(Measurements.cov(v,v)), @inferred(Measurements.cov(w,w))] ≈ [0.0025, 0.01, 0.0425]
+    @test [@inferred(Measurements.cov(u,v)), @inferred(Measurements.cov(v,w)), @inferred(Measurements.cov(u,w))] ≈ [0.0, 0.02, 0.0025]
 end
 
 @testset "Correlation matrix" begin
@@ -108,11 +112,15 @@ end
     y = -2x + 10
     z = -3x
     @test @inferred(Measurements.cor([x, y, z])) ≈ [1.0 -1.0 -1.0; -1.0 1.0 1.0; -1.0 1.0 1.0]
+    @test @inferred(Measurements.cor(x,x)) ≈ @inferred(Measurements.cor(y,y)) ≈ @inferred(Measurements.cor(z,z)) ≈ 1.0
+    @test [@inferred(Measurements.cor(x,y)), @inferred(Measurements.cor(y,z)), @inferred(Measurements.cor(x,z))] ≈ [-1.0, 1.0, -1.0]
 
     u = measurement(1, 0.05)
     v = measurement(10, 0.1)
     w = u + 2v
     @test @inferred(Measurements.cor([u, v, w])) ≈ [1.0 0.0 0.24253562503633297; 0.0 1.0 0.9701425001453319; 0.24253562503633297 0.9701425001453319 1.0] atol=1e-15
+    @test @inferred(Measurements.cor(u,u)) ≈ @inferred(Measurements.cor(v,v)) ≈ @inferred(Measurements.cor(w,w)) ≈ 1.0
+    @test [@inferred(Measurements.cor(u,v)), @inferred(Measurements.cor(v,w)), @inferred(Measurements.cor(u,w))] ≈ [0.0, 0.9701425001453319, 0.24253562503633297]
 end
 
 @testset "Correlated values" begin


### PR DESCRIPTION
The current `cor` and `cov` methods are great when one wants a covariance matrix, but recently I've found myself wanting to calculate the (scalar) covariance between just a single pair of `Measurement`s many times. This turned out to be rather easy to implement, so figured I'd PR it!